### PR TITLE
2文字の変数に警告が出ていたので、swiftlintのidentifier_nameを2文字以上に設定。

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,3 +29,6 @@ disabled_rules: # 無効にするルール
 line_length: 200
 number_separator:
   minimum_length: 5
+  
+identifier_name:
+  min_length: 2


### PR DESCRIPTION
VCの変数名が全部警告できてたので、追加します。
