### PR TITLE
検索結果が最大10件しか表示できてなかったので、100件まで表示させる

### DIFF
--- a/RestaurantSearch/API/APIOperater.swift
+++ b/RestaurantSearch/API/APIOperater.swift
@@ -64,9 +64,10 @@ final class APIOperater: APIType {
     /// エリア・フリーワードからお店情報の取得
     func getShop(townCode: String, freeword: String, success: @escaping (ShopResponseBody) -> Void, failure: @escaping (Error) -> Void) {
         let url = "https://api.gnavi.co.jp/RestSearchAPI/v3/"
-        let parameters = [
+        let parameters: [String: Any] = [
             "areacode_s": townCode,
-            "freeword": freeword
+            "freeword": freeword,
+            "hit_per_page": 100
         ]
         fetchResponse(url: url, parameters: parameters, success: success, failure: failure)
     }


### PR DESCRIPTION
 #70
今までデフォルトで1ページあたり10件までしか取得できない設定になっていたので、検索結果が10件以上ある場合も10件しか表示されていなかった。

2ページ目を表示するには、
 "page_offset": 2
というように、追加のパラメーターを指定して、再取得しなければならない。

とりあえず、1ページあたり100件まで取得できるような設定にし、検索結果が最大100件表示できるようにする。
→　お店情報取得の際のパラメーターに、"hit_per_page": 100を追加