### PR TITLE
日本語表示設定の時コミットもれしていたファイルを追加

### DIFF
--- a/RestaurantSearch.xcodeproj/project.pbxproj
+++ b/RestaurantSearch.xcodeproj/project.pbxproj
@@ -544,6 +544,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ja,
 			);
 			mainGroup = EA2679D92248CCBF00F3091C;
 			productRefGroup = EA2679E32248CCBF00F3091C /* Products */;


### PR DESCRIPTION
ずっとコミット対象ファイルとして、SouceTree上で表示されていたので、
おそらくコミット漏れしていたのではないかと。。