### PR TITLE
地図の表示される範囲が広すぎるので、狭くする

### DIFF
--- a/RestaurantSearch/UI/ShopInfo/ShopInfoViewController.swift
+++ b/RestaurantSearch/UI/ShopInfo/ShopInfoViewController.swift
@@ -104,7 +104,7 @@ final class ShopInfoViewController: UITableViewController {
         let center = CLLocationCoordinate2DMake(latitude, longitude)
         mapView.setCenter(center, animated: true)
         
-        let span = MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        let span = MKCoordinateSpan(latitudeDelta: 0.005, longitudeDelta: 0.005)
         let region = MKCoordinateRegion(center: center, span: span)
         mapView.region = region
         

--- a/RestaurantSearch/UI/ShopMap/ShopMapViewController.swift
+++ b/RestaurantSearch/UI/ShopMap/ShopMapViewController.swift
@@ -33,7 +33,7 @@ final class ShopMapViewController: UIViewController {
         let center = CLLocationCoordinate2DMake(latitude, longitude)
         mapView.setCenter(center, animated: true)
         
-        let span = MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        let span = MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
         let region = MKCoordinateRegion(center: center, span: span)
         mapView.region = region
         


### PR DESCRIPTION
#114 

最初に表示される範囲が広すぎて、位置がわかりずらいので
より詳細に表示されるようにする。